### PR TITLE
Try and make platform detection more robust

### DIFF
--- a/athena_builder
+++ b/athena_builder
@@ -20,7 +20,7 @@ sub fatal($) {
 
 
 my $required_packages = {
-	'ubuntu' => [
+	'ubuntu18.04' => [
 		'libterm-readline-gnu-perl',
 		'build-essential',
 		'git',
@@ -45,7 +45,7 @@ my $required_packages = {
 		'nodejs'
 
 	],
-	'fedora' => [
+	'fedora31' => [
 		'git',
 		'perl-Term-ReadLine-Gnu',
 		'cmake',
@@ -73,29 +73,30 @@ setup_desktop();
 sub detect_distro {
 	info "Detecting distribution... ";
 
-	if ( -f "/etc/fedora-release" ) {
-		info "Fedora\n";
-		return "fedora";
+	my %os=();
+
+	unless ( open(OS,"cat /etc/os-release|") ){
+		die "Failed to detect distribution!";
 	}
 
-	if ( -f "/etc/lsb-release" ) {
-		my @lsb = readfile("/etc/lsb-release");
-		my ($dist) = grep { /^DISTRIB_ID/ } @lsb;
-		my ($f, $v) = split(/=/, $dist);
-		return lc($v);
+	while (<OS>){
+		my @os_param = split /=/, $_;
+		@os_param[1] =~ tr/"//d;
+		@os_param[1] =~ tr/\n//d;
+		$os{$os_param[0]} = $os_param[1];
 	}
 
-	die "Failed to detect distribution!";
+	return $os{ID}.$os{VERSION_ID};
 }
 
 
 
 sub get_package_list {
-	info "Getting the package list... ";	
+	info "Getting the package list... ";
 	my @packages;
-	if ( $DISTRO eq "fedora" ) {
+	if ( $DISTRO eq "fedora31" ) {
 		@packages = `rpm -qa --qf "%{NAME}\\n"`
-	} elsif ( $DISTRO eq "ubuntu" ) {
+	} elsif ( $DISTRO eq "ubuntu18.04" ) {
 		@packages = `dpkg-query --show -f "\\\${Package}\n"`
 	}
 
@@ -113,9 +114,9 @@ sub install_missing_packages {
 	if ( @missing ) {
 		print scalar(@missing) . " additional packages needed: " . join(", ", @missing) . "\n";
 
-		if ( $DISTRO eq "fedora" ) {
+		if ( $DISTRO eq "fedora31" ) {
 			sudo_run("dnf", "install", "-y", @missing);
-		} elsif ( $DISTRO eq "ubuntu" ) {
+		} elsif ( $DISTRO eq "ubuntu18.04" ) {
 			sudo_run("apt-get", "install", "-y", @missing);
 		}
 


### PR DESCRIPTION
All systemd based linux distros should have an `/etc/os-release` file that provides info like `ID` and `VERSION_ID`. This attempts to make all of that info accessible to the perl script if needed.

I haven't used perl in literally 20 years. This may be a horror. If so, apologies!